### PR TITLE
Update deprecated js and css Sphinx commands

### DIFF
--- a/sphinxcontrib/contentui.py
+++ b/sphinxcontrib/contentui.py
@@ -80,8 +80,8 @@ class ToggleDirective(Directive):
 
 
 def add_assets(app):
-    app.add_stylesheet(CSS_FILE)
-    app.add_javascript(JS_FILE)
+    app.add_css_file(CSS_FILE)
+    app.add_js_file(JS_FILE)
 
 
 def copy_assets(app, exception):


### PR DESCRIPTION
`add_javascript()` and `add_stylesheet()` are deprecated Sphinx commands, and should be updated to remove any RemovedInSphinx warning messages when building.

- Sphinx 3.x.x will show RemovedInSphinx warning messages about deprecation, but both the old format and expected format will work either way.
- Sphinx 4.x.x will be dropping all support for `.add_javascript()` and `.add_stylesheet()`, moving to `.add_js_file()` and `.add_css_file()`. The old format will no longer work in Sphinx 4.x.x.
- These changes happened back in 1.8, so should work with sphinx>=1.8.0
  - [Sphinx Docs: add_js_file](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file)
  - [Sphinx Docs: add_css_file](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file)