### PR TITLE
Fix singlehtml builder and button re-click 

### DIFF
--- a/sphinxcontrib/contentui.js
+++ b/sphinxcontrib/contentui.js
@@ -53,6 +53,10 @@ $(function() {
 
     $('.contenttab-selector li').click(function(evt) {
         evt.preventDefault();
+        
+        if(this.classList.contains('selected')) {
+            return;
+        }
 
         if ($(this).parents('.in-right-col').length){
             var tabsblock = $('.right-col');

--- a/sphinxcontrib/contentui.py
+++ b/sphinxcontrib/contentui.py
@@ -85,7 +85,7 @@ def add_assets(app):
 
 
 def copy_assets(app, exception):
-    if app.builder.name not in ['html', 'readthedocs'] or exception:
+    if app.builder.name not in ['singlehtml','html','readthedocs'] or exception:
         return
     logger = logging.getLogger(__name__)
     logger.info('Copying contentui stylesheet/javascript... ', nonl=True)


### PR DESCRIPTION
Fixed

1. Sphinxcontrib assets are not included when using `singlehtml` builder
1. Content disappears after re-click on the same button (tab)